### PR TITLE
feat: fixed invitations

### DIFF
--- a/api/main-api/rest/v1/components/invitations/components.yml
+++ b/api/main-api/rest/v1/components/invitations/components.yml
@@ -34,7 +34,7 @@ components:
         role:
           type: string
           description: Role to assign to the invitee
-          enum: [OWNER, MANAGER, EMPLOYEE]
+          enum: [MANAGER, EMPLOYEE]
           example: "MANAGER"
       required:
         - email

--- a/api/main-api/rest/v1/services/invitations/invitations-operations.yml
+++ b/api/main-api/rest/v1/services/invitations/invitations-operations.yml
@@ -137,7 +137,6 @@ invitations:
           schema:
             type: string
             enum: [ PENDING, ACCEPTED, DECLINED, EXPIRED ]
-            default: PENDING
       responses:
         '200':
           description: Invitations retrieved successfully
@@ -218,7 +217,6 @@ invitations:
           schema:
             type: string
             enum: [ PENDING, ACCEPTED, DECLINED, EXPIRED ]
-            default: PENDING
       responses:
         '200':
           description: Invitations retrieved successfully


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Invitation filters now require you to choose a status explicitly; results no longer default to “Pending,” enabling broader or targeted views (e.g., all statuses when no filter is applied).
  - Invitation creation no longer supports inviting users as “Owner”; only “Manager” and “Employee” roles are available for new invitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->